### PR TITLE
LTSMPS-625 Support for multiple annotations per page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-lts/mirador-annotations-auth-plugin",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-lts/mirador-annotations-auth-plugin",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "react-component"
     ],
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "A Mirador 3 plugin for including authentication cookies for annotations.",
     "module": "dist/es/index.js",
     "files": [

--- a/src/plugins/component.js
+++ b/src/plugins/component.js
@@ -15,10 +15,10 @@ export default class AnnotationsAuthSidePanel extends Component {
     this.handleClick = this.handleClick.bind(this);
     this.handleAnnotationHover = this.handleAnnotationHover.bind(this);
     this.handleAnnotationBlur = this.handleAnnotationBlur.bind(this);
-    const { windowId, canvasAnnotationPage } = this.props;
+    const { windowId, canvasAnnotationPages } = this.props;
     this.state = {
       windowId: windowId,
-      canvasAnnotationPage: canvasAnnotationPage,
+      canvasAnnotationPages: canvasAnnotationPages,
     };
   }
 
@@ -52,25 +52,38 @@ export default class AnnotationsAuthSidePanel extends Component {
   }
 
   async componentDidMount() {
-    const { canvasAnnotationPage } = this.state;
-    fetch(canvasAnnotationPage, {
-      method: 'get',
-      credentials: 'include',
-    })
-      .then(response => {
-        if (!response.ok) {
-            throw new Error('Network response was not ok');
+    const { canvasAnnotationPages } = this.state;
+    const promises = [];
+    canvasAnnotationPages.forEach(function (annotationPage, index) {
+      const promise = new Promise(async (resolve, reject) => {
+        try {
+          const result = await 
+            fetch(
+              annotationPage, 
+              {
+                method: 'get', 
+                credentials: 'include',
+              }
+            );
+          resolve(result.json());
+        } catch (error) {
+          reject('Network response was not ok');
         }
-        return response.json();
-      })
-      .then(annotationData => {
-        this.setState({ annotationData, loading: false });
-      })
-      .catch(error => {
-        console.error('There was a problem receiving the annotation:', error);
-        this.setState({ loading: false, error: error.message });
+      });
+      promises.push(promise);
     });
-  }
+
+    try {
+      const results = await Promise.all(promises);
+      this.setState({
+        annotationData: results,
+        loading: false,
+      });
+    } catch (error) {
+      console.error('There was a problem receiving the annotation:', error);
+      this.setState({ loading: false, error: error.message });
+    }
+ }
 
   render() {
     const { classes, 
@@ -86,54 +99,59 @@ export default class AnnotationsAuthSidePanel extends Component {
     if ({ annotationData }.length === 0) return <></>;
     return (
         <>
-        <Typography className={classes.sectionHeading} variant="overline">
-          { canvasLabel }
-          {loading && <p>Loading...</p>}
-          {error && <p>Error: {error}</p>}
-        </Typography>
-        <MenuList autoFocusItem variant="selectedMenu">
-          <ScrollTo
-            containerRef={containerRef}
-            key={`${{ annotationData }.id}-scroll`}
-            offsetTop={96} // offset for the height of the form above
-            scrollTo={selectedAnnotationId === { annotationData }.id}
-          >
-            <MenuItem
-              button
-              component={listContainerComponent}
-              className={clsx(
-                classes.annotationListItem,
-                {
-                  [classes.hovered]: hoveredAnnotationIds.includes({ annotationData }.id),
-                },
-              )}
-              key={{ annotationData }.id}
-              annotationid={{ annotationData }.id}
-              selected={selectedAnnotationId === { annotationData }.id}
-              onClick={e => this.handleClick(e, { annotationData })}
-              onFocus={() => this.handleAnnotationHover({ annotationData })}
-              onBlur={this.handleAnnotationBlur}
-              onMouseEnter={() => this.handleAnnotationHover({ annotationData })}
-              onMouseLeave={this.handleAnnotationBlur}
-            >
-              <ListItemText primaryTypographyProps={{ variant: 'body2' }}>
-              {annotationData && (
-                  <SanitizedHtml
-                  ruleSet={htmlSanitizationRuleSet}
-                  htmlString={annotationData.resources[0].resource.chars}
-                />
-              )}
-              </ListItemText>
-            </MenuItem>
-          </ScrollTo>
-        </MenuList>
+          <Typography className={classes.sectionHeading} variant="overline">
+            { canvasLabel }
+            {loading && <p>Loading...</p>}
+            {error && <p>Error: {error}</p>}
+          </Typography>
+          {annotationData && (
+            <>
+            {
+            annotationData.map((annotation, i) =>
+              <MenuList autoFocusItem variant="selectedMenu">
+                <ScrollTo
+                  containerRef={containerRef}
+                  key={`${{ annotation }.id}-scroll`}
+                  offsetTop={96} // offset for the height of the form above
+                  scrollTo={selectedAnnotationId === { annotation }.id}
+                >
+                  <MenuItem
+                    button
+                    component={listContainerComponent}
+                    className={clsx(
+                      classes.annotationListItem,
+                      {
+                        [classes.hovered]: hoveredAnnotationIds.includes({ annotation }.id),
+                      },
+                    )}
+                    key={{ annotation }.id}
+                    annotationid={{ annotation }.id}
+                    selected={selectedAnnotationId === { annotation }.id}
+                    onClick={e => this.handleClick(e, { annotation })}
+                    onFocus={() => this.handleAnnotationHover({ annotation })}
+                    onBlur={this.handleAnnotationBlur}
+                    onMouseEnter={() => this.handleAnnotationHover({ annotation })}
+                    onMouseLeave={this.handleAnnotationBlur}
+                  >
+                    <ListItemText primaryTypographyProps={{ variant: 'body2' }}>
+                      <SanitizedHtml
+                        ruleSet={htmlSanitizationRuleSet}
+                        htmlString={annotation.resources[0].resource.chars}
+                      />
+                    </ListItemText>
+                  </MenuItem>
+                </ScrollTo>
+              </MenuList>
+            )}
+            </>
+          )}
         </>
     );
   }
 }
 
 AnnotationsAuthSidePanel.propTypes = {
-  canvasAnnotationPage: PropTypes.string,
+  canvasAnnotationPages: PropTypes.arrayOf(PropTypes.string),
   canvasLabel: PropTypes.string,
   classes: PropTypes.objectOf(PropTypes.string),
   htmlSanitizationRuleSet: PropTypes.string,
@@ -146,7 +164,7 @@ AnnotationsAuthSidePanel.propTypes = {
 };
 
 AnnotationsAuthSidePanel.defaultProps = {
-  canvasAnnotationPage: null,
+  canvasAnnotationPages: [],
   canvasLabel: null,
   classes: {},
   htmlSanitizationRuleSet: 'iiif',

--- a/src/plugins/plugin.js
+++ b/src/plugins/plugin.js
@@ -22,27 +22,40 @@ const styles = theme => ({
 });
 
 /** */
-function getAnnotationPage(canvases, canvasIds) {
+function getAnnotationPages(canvases, canvasIds) {
   let annotationPage = null;
+  let annotationPagesArray = [];
+  let annotationPages = [];
   for (let i = 0; i < canvases.length; i++) {
     if (canvases[i].id === canvasIds[0]) {
       if (canvases[i].__jsonld.otherContent !== undefined) {
         // Version 2 Annotation Page
         annotationPage = canvases[i].__jsonld.otherContent[0]["@id"];
+        annotationPagesArray = canvases[i].__jsonld.otherContent;
+        for (let j = 0; j < annotationPagesArray.length; j++) {
+          if (annotationPagesArray[j]["@type"] === "sc:AnnotationList") {
+            annotationPages[j] = annotationPagesArray[j]["@id"];
+          }
+        }
       }
       if (canvases[i].__jsonld.annotations !== undefined) {
         // Version 3 Annotation Page
         annotationPage = canvases[i].__jsonld.annotations[0].id;
+        annotationPagesArray = canvases[i].__jsonld.annotations;
+        for (let j = 0; j < annotationPagesArray.length; j++) {
+          if (annotationPagesArray[j].type === "AnnotationPage") {
+            annotationPages[j] = annotationPagesArray[j].id;
+          }
+        }
       }
       break;
     }
   }
-  console.log('annotationPage', annotationPage);
-  return annotationPage;
+  return annotationPages;
 }
 
 const mapStateToProps = (state, { canvasId, windowId }) => ({
-  canvasAnnotationPage: getAnnotationPage(getCanvases(state, { windowId }), getVisibleCanvasIds(state, { windowId })),
+  canvasAnnotationPages: getAnnotationPages(getCanvases(state, { windowId }), getVisibleCanvasIds(state, { windowId })),
   canvasLabel: getCanvasLabel(state, { canvasId, windowId }),
   windowId: windowId,
 });


### PR DESCRIPTION
**LTSMPS-625 Support for multiple annotations per page.**

---

**JIRA Ticket**: [LTSMPS-625](https://at-harvard.atlassian.net/browse/LTSMPS-625)

# What does this Pull Request do?

The old version of the plugin only displayed one annotation per page. If there were multiple annotations it would only display the first one defined in the manifest. This updates the plugin to display all annotations that exist for each page.

# How should this be tested?

A description of what steps someone could take to:

- Pull in the latest code from the `ltsmps-625-multiple-annotations` branch
- Update the `demo/demoEntry.src` file to include the examples in this JIRA comment: https://at-harvard.atlassian.net/browse/LTSMPS-625?focusedCommentId=745569
- Follow the [setup steps in the README](https://github.com/harvard-lts/mirador-annotations-auth-plugin?tab=readme-ov-file#setup) if you are using the plugin for the first time.
- Run this command to start a local version of Mirador with the plugin installed: `npm run serve`
- You should see 4 objects in Mirador. Two Dev objects (v2 and v3 manifest) and Two QA objects (v2 and v3 manifest). 
- If you are logged out in the environments you should not see the objects and clicking on the annotations icon should display no annotations.
- After logging in to both environments, you should see the objects (after toggling a page). You should also see the annotations appear. For the QA object, the first annotation will be blank and the second annotation will display. _NOTE: Dev login is potentially wonky. If the login window does not automatically close, that is ok. Just close it manually and continue._

# Test coverage

Yes/No: Are changes in this pull-request covered by:

- unit tests? No
- integration tests? No

# Interested parties

@f8f8ff @enriquediaz 


[LTSMPS-625]: https://at-harvard.atlassian.net/browse/LTSMPS-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ