### PR TITLE
LTSVIEWER-371 Checking for inline annotations.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-lts/mirador-annotations-auth-plugin",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-lts/mirador-annotations-auth-plugin",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "react-component"
     ],
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "A Mirador 3 plugin for including authentication cookies for annotations.",
     "module": "dist/es/index.js",
     "files": [

--- a/src/plugins/component.js
+++ b/src/plugins/component.js
@@ -15,10 +15,11 @@ export default class AnnotationsAuthSidePanel extends Component {
     this.handleClick = this.handleClick.bind(this);
     this.handleAnnotationHover = this.handleAnnotationHover.bind(this);
     this.handleAnnotationBlur = this.handleAnnotationBlur.bind(this);
-    const { windowId, canvasAnnotationPages } = this.props;
+    const { windowId, canvasAnnotationPages, canvasAnnotationList } = this.props;
     this.state = {
       windowId: windowId,
       canvasAnnotationPages: canvasAnnotationPages,
+      canvasAnnotationList: canvasAnnotationList,
     };
   }
 
@@ -52,7 +53,16 @@ export default class AnnotationsAuthSidePanel extends Component {
   }
 
   async componentDidMount() {
-    const { canvasAnnotationPages } = this.state;
+    const { canvasAnnotationPages, canvasAnnotationList } = this.state;
+    if (canvasAnnotationList.json !== undefined) {
+      if (canvasAnnotationList.json[0].items !== undefined) {
+        this.setState({
+          annotationData: canvasAnnotationList.json[0].items,
+          loading: false,
+        });
+        return;
+      }
+    }
     const promises = [];
     canvasAnnotationPages.forEach(function (annotationPage, index) {
       const promise = new Promise(async (resolve, reject) => {
@@ -136,7 +146,7 @@ export default class AnnotationsAuthSidePanel extends Component {
                     <ListItemText primaryTypographyProps={{ variant: 'body2' }}>
                       <SanitizedHtml
                         ruleSet={htmlSanitizationRuleSet}
-                        htmlString={annotation.resources[0].resource.chars}
+                        htmlString={annotation.body?.value || annotation.resources?.[0]?.resource?.chars || ''}
                       />
                     </ListItemText>
                   </MenuItem>
@@ -152,6 +162,7 @@ export default class AnnotationsAuthSidePanel extends Component {
 
 AnnotationsAuthSidePanel.propTypes = {
   canvasAnnotationPages: PropTypes.arrayOf(PropTypes.string),
+  canvasAnnotationList: PropTypes.arrayOf(PropTypes.object),
   canvasLabel: PropTypes.string,
   classes: PropTypes.objectOf(PropTypes.string),
   htmlSanitizationRuleSet: PropTypes.string,
@@ -165,6 +176,7 @@ AnnotationsAuthSidePanel.propTypes = {
 
 AnnotationsAuthSidePanel.defaultProps = {
   canvasAnnotationPages: [],
+  canvasAnnotationList: [],
   canvasLabel: null,
   classes: {},
   htmlSanitizationRuleSet: 'iiif',

--- a/src/plugins/plugin.js
+++ b/src/plugins/plugin.js
@@ -4,6 +4,7 @@ import AnnotationsAuthSidePanel from './component';
 import { withStyles } from '@material-ui/core/styles';
 import { withTranslation } from 'react-i18next';
 import { getVisibleCanvasIds, getCanvases, getCanvasLabel } from 'mirador/dist/es/src/state/selectors';
+import AnnotationFactory from 'mirador/dist/es/src/lib/AnnotationFactory';
 
 const styles = theme => ({
   section: {
@@ -54,8 +55,27 @@ function getAnnotationPages(canvases, canvasIds) {
   return annotationPages;
 }
 
+function getAnnotationList(canvases, canvasIds) {
+  let annotationList = [];
+  for (let i = 0; i < canvases.length; i++) {
+    if (canvases[i].id === canvasIds[0]) {
+      if (canvases[i].__jsonld.otherContent !== undefined) {
+        // Version 2 Annotation Page
+        annotationList = AnnotationFactory.determineAnnotation(canvases[i].__jsonld.otherContent);
+      }
+      if (canvases[i].__jsonld.annotations !== undefined) {
+        // Version 3 Annotation Page
+        annotationList = AnnotationFactory.determineAnnotation(canvases[i].__jsonld.annotations);
+      }
+      break;
+    }
+  }
+  return annotationList;
+}
+
 const mapStateToProps = (state, { canvasId, windowId }) => ({
   canvasAnnotationPages: getAnnotationPages(getCanvases(state, { windowId }), getVisibleCanvasIds(state, { windowId })),
+  canvasAnnotationList: getAnnotationList(getCanvases(state, { windowId }), getVisibleCanvasIds(state, { windowId })),
   canvasLabel: getCanvasLabel(state, { canvasId, windowId }),
   windowId: windowId,
 });


### PR DESCRIPTION
**LTSVIEWER-371 Checking for inline annotations.**

---

**JIRA Ticket**: [LTSVIEWER-371](https://at-harvard.atlassian.net/browse/LTSVIEWER-371)

# What does this Pull Request do?

This updates the plugin to also look for annotations inside the manifest as opposed to just ones that are external by IDs. 

# How should this be tested?

A description of what steps someone could take to:

- Pull in the `LTSVIEWER-371-emily-annotations` branch
- Run `npm install` if you haven't before for this plugin
- Run `npm run serve`. It will open a new Mirador instance in a browser window at http://localhost:9000/
- You can confirm that the two objects there do not display restricted annotations because you are not logged in.
- Click the `+` button in Mirador to add a new resource and add this manifest: https://gist.githubusercontent.com/kirkkwang/051fea93c17728c892559f61b60c1c64/raw/f2c2dd9bc39af66e944d526f40153dbb2baf295f/eda_test_manifest.json
- Click on the hamburger menu and then the annotations button. Confirm that 5 annotations show up for this object.
- You can add another public Harvard object with annotations such as this one and confirm that the annotations show up properly as well: https://nrs.harvard.edu/URN-3:FHCL:106214677:MANIFEST:3


[LTSVIEWER-371]: https://at-harvard.atlassian.net/browse/LTSVIEWER-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ