### PR TITLE
Ltsviewer 395 update qs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14133,9 +14133,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-            "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "version": "6.14.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@harvard-lts/mirador-annotations-auth-plugin",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@harvard-lts/mirador-annotations-auth-plugin",
-            "version": "0.0.7",
+            "version": "0.0.8",
             "license": "Apache-2.0",
             "dependencies": {
                 "jquery": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,18 @@
         "prop-types": "^15.8.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
+    },
+  "overrides": {
+    "url": {
+      "qs": "^6.14.1"
+    },
+    "webpack-dev-server": {
+      "qs": {
+        "version": "^6.14.1",
+        "dependencies": {
+          "qs": "^6.14.1"
+        }
+      }
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "keywords": [
         "react-component"
     ],
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "A Mirador 3 plugin for including authentication cookies for annotations.",
     "module": "dist/es/index.js",
     "files": [
@@ -52,17 +52,17 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
     },
-  "overrides": {
-    "url": {
-      "qs": "^6.14.1"
-    },
-    "webpack-dev-server": {
-      "qs": {
-        "version": "^6.14.1",
-        "dependencies": {
-          "qs": "^6.14.1"
+    "overrides": {
+        "url": {
+            "qs": "^6.14.1"
+        },
+        "webpack-dev-server": {
+            "qs": {
+                "version": "^6.14.1",
+                "dependencies": {
+                    "qs": "^6.14.1"
+                }
+            }
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
**LTSVIEWER-395 Update qs dependency**

---

**JIRA Ticket**: [LTSVIEWER-395](https://at-harvard.atlassian.net/browse/LTSVIEWER-395)

# What does this Pull Request do?
Update version of qs to address [CVE-2025-15284](https://github.com/advisories/GHSA-6rw7-vpxm-498p)

# How should this be tested?
- checkout `LTSVIEWER-395-update-qs` locally
- run `npm i`
- run `npm run serve` and confirm that examples in demo/demoEntry.js are displayed as expected
- run `npm ls qs` and ensure that version(s) is 6.14.1 or above

# Test coverage
Yes/No: Are changes in this pull-request covered by:

- unit tests? no
- integration tests? no

[LTSVIEWER-395]: https://at-harvard.atlassian.net/browse/LTSVIEWER-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ